### PR TITLE
修复了一个由metadata.yaml引起的报错

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-name: hello-bye # 这是你的插件的唯一识别名。
+name: astrbot_plugin_hello_bye # 这是你的插件的唯一识别名。
 desc: 进群（不同群可自定义）或退群消息提示，支持黑名单 # 插件简短描述
 version: v1.11 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: tinker # 作者

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,5 @@
 name: astrbot_plugin_hello_bye # 这是你的插件的唯一识别名。
+display-name: hello-bye
 desc: 进群（不同群可自定义）或退群消息提示，支持黑名单 # 插件简短描述
 version: v1.11 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: tinker # 作者


### PR DESCRIPTION
#21 metadata.yaml 中 name 不是合法的模块名称（应为合法 Python 标识符且非关键字）。

修改：
```
+ name: astrbot_plugin_hello_bye # 这是你的插件的唯一识别名。
+ display-name: hello-bye
```

## Summary by Sourcery

更新插件元数据，使插件名称使用合法的 Python 标识符，并额外提供一个可读性更好的显示名称。

Bug 修复：
- 修复 `metadata.yaml` 中无效的插件名称（该名称不是合法的 Python 标识符），将其替换为合法的模块风格名称。

增强改进：
- 在 `metadata.yaml` 中新增独立的 `display-name` 字段，用于插件的易读显示名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update plugin metadata to use a valid Python identifier as the plugin name and expose a separate human-readable display name.

Bug Fixes:
- Fix invalid plugin name in metadata.yaml that was not a legal Python identifier by replacing it with a valid module-style name.

Enhancements:
- Add a separate display-name field in metadata.yaml for the plugin's human-readable name.

</details>